### PR TITLE
fix: hub, jwt, and automations bugs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v4

--- a/Rownd/Controls/HubBottomSheetPage.xaml.cs
+++ b/Rownd/Controls/HubBottomSheetPage.xaml.cs
@@ -336,7 +336,7 @@ namespace Rownd.Controls
 
             // Ignore small, negative adjustments in height
             var heightDifference = Math.Abs(Math.Abs(position) - Math.Abs(currentPosition));
-            if (heightDifference < 99)
+            if (heightDifference < 25)
             {
                 return;
             }

--- a/Rownd/Hub/HubWebView.cs
+++ b/Rownd/Hub/HubWebView.cs
@@ -50,7 +50,33 @@ namespace Rownd.Maui.Hub
             await InitializeWebView();
         }
 
-        internal async void RenderHub()
+        internal async Task RenderHub()
+        {
+            if (this.Handler == null)
+            {
+                EventHandler? handler = null;
+                handler = (object? s, EventArgs e) =>
+                {
+                    if (this.Handler?.PlatformView == null)
+                    {
+                        return;
+                    }
+
+                    Task.Run(async () =>
+                    {
+                        await this.RenderHubInternal();
+                    });
+                    this.HandlerChanged -= handler;
+                };
+                this.HandlerChanged += handler;
+
+                return;
+            }
+
+            await this.RenderHubInternal();
+        }
+
+        private async Task RenderHubInternal()
         {
             var url = await config.GetHubLoaderUrl();
             MainThread.BeginInvokeOnMainThread(async () =>

--- a/Rownd/Models/StateReducers.cs
+++ b/Rownd/Models/StateReducers.cs
@@ -65,8 +65,8 @@
                         }
 
                         return action.SignInState;
-                    }
-                ).ToList();
+                    })
+                .ToList();
         }
     }
 }

--- a/Rownd/RowndInstance.cs
+++ b/Rownd/RowndInstance.cs
@@ -151,7 +151,7 @@ namespace Rownd.Maui
         }
 
         #region Internal methods
-        internal async void DisplayHub(HubPageSelector page, RowndSignInJsOptions? opts = null)
+        internal async Task DisplayHub(HubPageSelector page, RowndSignInJsOptions? opts = null)
         {
             await MainThread.InvokeOnMainThreadAsync(async () =>
             {

--- a/Rownd/Utils/TimeManager.cs
+++ b/Rownd/Utils/TimeManager.cs
@@ -30,7 +30,7 @@ public class TimeManager
 
             var timePassed = default(DateTime).Subtract(FetchTime.Value);
 
-            return FetchedWorldTime.Value.Add(timePassed);
+            return FetchedWorldTime.Value.Add(timePassed).ToUniversalTime();
         }
     }
 


### PR DESCRIPTION
* Launching the hub for an automation or to recover an auth challenge (e.g., if the app restarted) could cause the app to crash.

* JWT validity checker was throwing an exception due to JSON serialization issues.

* JWT validity was not being computed properly due to a mismatch between UTC and non-UTC DateTime parsing.